### PR TITLE
Massively reimplement applyColorSchemeJs

### DIFF
--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -339,6 +339,8 @@ function dispatchChangeEvents() {
         } else {
             lastSeenJsColorStatus = systemMediaStatus;
         }
+    } else if (lastSeenJsColorStatus === fakedColorStatus) {
+        return;
     } else {
         lastSeenJsColorStatus = fakedColorStatus;
     }

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -367,6 +367,7 @@ function applyJsOverwrite() {
     // do not overwrite twice
     if (overwroteMatchMedia) {
         dispatchChangeEvents();
+        jsLastColorStatus = fakedColorStatus;
         return;
     }
 

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -328,10 +328,14 @@ function makeListenerHook(listener) {
  * @private
  */
 function dispatchChangeEvents() {
-    if (fakedColorStatus === COLOR_STATUS.NO_OVERWRITE &&
-        jsLastColorStatus === getSystemMediaStatus()
-    ) {
-        return;
+    if (fakedColorStatus === COLOR_STATUS.NO_OVERWRITE) {
+        let systemMediaStatus = getSystemMediaStatus();
+        if (jsLastColorStatus === systemMediaStatus) {
+            return;
+        } else {
+            // eslint-disable-next-line no-global-assign
+            jsLastColorStatus = systemMediaStatus;
+        }
     }
 
     // [CAVEAT]
@@ -367,12 +371,16 @@ function applyJsOverwrite() {
     // do not overwrite twice
     if (overwroteMatchMedia) {
         dispatchChangeEvents();
-        jsLastColorStatus = fakedColorStatus;
         return;
     }
 
-    // eslint-disable-next-line no-global-assign
-    jsLastColorStatus = fakedColorStatus;
+    if (fakedColorStatus === COLOR_STATUS.NO_OVERWRITE) {
+        // eslint-disable-next-line no-global-assign
+        jsLastColorStatus = getSystemMediaStatus();
+    } else {
+        // eslint-disable-next-line no-global-assign
+        jsLastColorStatus = fakedColorStatus;
+    }
 
     // actually overwrite
 

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -35,9 +35,6 @@ const originalRemoveEventListener = EventTargetPrototype.removeEventListener;
 // ugly juggling principals
 const unsafeObjectCreate = window.wrappedJSObject.Object.create;
 
-// keep track of our generated fake events
-const wmFakeEvents = new WeakSet();
-
 // Whether we are dispatching "change" events
 let dispatching = false;
 
@@ -297,7 +294,6 @@ function dispatchChangeEvents() {
             media: mediaQueryList.media,
             matches: result
         });
-        wmFakeEvents.add(event);
         mediaQueryList.dispatchEvent(event);
     }
     dispatching = false;

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -1,5 +1,7 @@
 /**
  * Applying the color's JS.
+ * 
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList}
  */
 
 "use strict";
@@ -41,10 +43,6 @@ let dispatching = false;
 
 // eslint does not include X-Ray vision functions, see https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
 /* globals exportFunction */
-
-//
-// See https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList
-//
 
 /**
  * Returns the COLOR_STATUS for a media query string.

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -39,7 +39,7 @@ const unsafeObjectCreate = window.wrappedJSObject.Object.create;
 // Whether we are dispatching "change" events
 let dispatching = false;
 
-/* globals COLOR_STATUS, MEDIA_QUERY_COLOR_SCHEME, MEDIA_QUERY_PREFER_COLOR, fakedColorStatus, getSystemMediaStatus, jsLastColorStatus:writable */
+/* globals COLOR_STATUS, MEDIA_QUERY_COLOR_SCHEME, MEDIA_QUERY_PREFER_COLOR, fakedColorStatus, getSystemMediaStatus, lastSeenJsColorStatus:writable */
 
 // eslint does not include X-Ray vision functions, see https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
 /* globals exportFunction */
@@ -332,10 +332,10 @@ function makeListenerHook(listener) {
 function dispatchChangeEvents() {
     if (fakedColorStatus === COLOR_STATUS.NO_OVERWRITE) {
         const systemMediaStatus = getSystemMediaStatus();
-        if (jsLastColorStatus === systemMediaStatus) {
+        if (lastSeenJsColorStatus === systemMediaStatus) {
             return;
         } else {
-            jsLastColorStatus = systemMediaStatus;
+            lastSeenJsColorStatus = systemMediaStatus;
         }
     }
 
@@ -376,9 +376,9 @@ function applyJsOverwrite() {
     }
 
     if (fakedColorStatus === COLOR_STATUS.NO_OVERWRITE) {
-        jsLastColorStatus = getSystemMediaStatus();
+        lastSeenJsColorStatus = getSystemMediaStatus();
     } else {
-        jsLastColorStatus = fakedColorStatus;
+        lastSeenJsColorStatus = fakedColorStatus;
     }
 
     // actually overwrite

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -240,7 +240,7 @@ const skeleton = {
         let oldHook = Reflect.apply(privilegedOnChangeGetter, this, arguments);
         if (typeof oldHook === 'function') {
             let oldFunc = wmHookToFunc.get(oldHook);
-            if (!oldFunc) {
+            if (typeof oldFunc !== 'function') {
                 console.error('[website-dark-mode-switcher] someone called "set onchange" on an unknown MediaQueryList!');
                 // eslint-disable-next-line no-setter-return
                 return Reflect.apply(originalOnChangeSetter, this, arguments);

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -4,14 +4,47 @@
 
 "use strict";
 
-const overwroteMatchMedia = false;
+let overwroteMatchMedia = false;
 
 const ADDON_FAKED_WARNING = "matchMedia has been faked/overwritten by add-on website-dark-mode-switcher; see https://github.com/rugk/website-dark-mode-switcher/. If it causes any problems, please open an issue.";
 
-/* globals COLOR_STATUS, MEDIA_QUERY_COLOR_SCHEME, MEDIA_QUERY_PREFER_COLOR, fakedColorStatus, getSystemMediaStatus */
+// instances of `MediaQueryList`s with listeners
+const setMediaQueryLists = new Set();
+
+// func -> { hook, setMediaQueryList, setMediaQueryListOnChange }
+const wmFuncToEntry = new WeakMap();
+
+// hook -> func
+const wmHookToFunc = new WeakMap();
+
+const originalMatchMedia = window.wrappedJSObject.matchMedia;
+
+const privilegedOnChangeGetter = Reflect.getOwnPropertyDescriptor(MediaQueryList.prototype, 'onchange').get;
+
+const MediaQueryListPrototype = MediaQueryList.prototype.wrappedJSObject;
+const originalAddListener = MediaQueryListPrototype.addListener;
+const originalRemoveListener = MediaQueryListPrototype.removeListener;
+const originalMatchesGetter = Reflect.getOwnPropertyDescriptor(MediaQueryListPrototype, 'matches').get;
+const originalOnChangeGetter = Reflect.getOwnPropertyDescriptor(MediaQueryListPrototype, 'onchange').get;
+const originalOnChangeSetter = Reflect.getOwnPropertyDescriptor(MediaQueryListPrototype, 'onchange').set;
+
+const EventTargetPrototype = window.EventTarget.prototype.wrappedJSObject;
+const originalAddEventListener = EventTargetPrototype.addEventListener;
+const originalRemoveEventListener = EventTargetPrototype.removeEventListener;
+
+// ugly juggling principals
+const unsafeObjectCreate = window.wrappedJSObject.Object.create;
+
+// keep track of our generated fake events
+const wmFakeEvents = new WeakSet();
+
+// Whether we are dispatching "change" events
+let dispatching = false;
+
+/* globals COLOR_STATUS, MEDIA_QUERY_COLOR_SCHEME, MEDIA_QUERY_PREFER_COLOR, fakedColorStatus, getSystemMediaStatus, jsColorStatus */
 
 // eslint does not include X-Ray vision functions, see https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
-/* globals exportFunction, cloneInto */
+/* globals exportFunction */
 
 /**
  * Returns the COLOR_STATUS for a media query string.
@@ -38,94 +71,240 @@ function getColorTypeFromMediaQuery(mediaQueryString) {
 }
 
 /**
- * Returns a fake MediaQueryList as best as possible.
+ * Evaluate a media query string.
+ * Returns null if the query has nothing to do with color.
  *
  * @private
- * @param {string} mediaQueryString the original media query string
- * @param {COLOR_STATUS} askedFor
- * @returns {Object} looks like MediaQueryList
+ * @param {string} mediaQueryString
+ * @returns {boolean|null}
  */
-function fakeMediaQueryResult(mediaQueryString, askedFor) {
-    let matches = false;
-
-    // only return true, if the asked status is the same as the one we want to fake
-    if (fakedColorStatus === askedFor) {
-        matches = true;
-    }
-
-    // get some parts of real object
-    const realQuery = matchMedia("(prefers-color-scheme: no-preference)");
-
-    return {
-        media: mediaQueryString,
-        matches: matches,
-        onchange: realQuery.onchange || null, // real value was null anyway in my tests
-        addListener: (...args) => {
-            console.warn(ADDON_FAKED_WARNING);
-
-            return realQuery.addListener(...args);
-
-            // TODO: if we really overwrite it and not exitend it, we get the error:
-            // TypeError: 'addListener' called on an object that does not implement interface MediaQueryList.
-            // …because we only fake/create an object, not a real MediaQueryList
-        },
-        removeListener: (...args) => {
-            console.warn(ADDON_FAKED_WARNING);
-
-            return realQuery.removeListener(...args);
-        },
-    };
+function evaluateMediaQuery(mediaQueryString) {
+	let requestedMedia = getColorTypeFromMediaQuery(mediaQueryString);
+	if (requestedMedia === null) {
+		return null;
+	}
+	return (fakedColorStatus === requestedMedia);
 }
 
 /**
- * The actual JS overwrite for window.matchMedia().
+ * Keep track of listener addition
+ * Creates hook function if necessary
  *
- * @function
- * @param {string} mediaQueryString
- * @returns {MediaQueryList}
- * @see {@link https://developer.mozilla.org/docs/Web/API/Window/matchMedia}
+ * @private
+ * @param {function} func original listener
+ * @param {MediaQueryList} mediaQueryList
+ * @param {boolean} isOnChange
+ * @returns {function} hook
  */
-function matchMediaOverwrite(...args) {
-    let mediaQueryString, requestedMedia;
-    try {
-        const mediaQueryString = args[0];
-        requestedMedia = getColorTypeFromMediaQuery(mediaQueryString);
-    } catch (e) {
-        // ignore errors and run the real browser function at the bottom
-        requestedMedia = null;
-    }
+function _OnListener(func, mediaQueryList, isOnChange) {
+	let entry = wmFuncToEntry.get(func);
 
-    switch (requestedMedia) {
-    case COLOR_STATUS.DARK:
-    case COLOR_STATUS.LIGHT:
-    case COLOR_STATUS.NO_PREFERENCE: {
-        const realColorStatus = getSystemMediaStatus();
-        console.info(
-            "Real media query result: ", realColorStatus, ".",
-            "We fake it to appear like: ", fakedColorStatus, ".",
-            ADDON_FAKED_WARNING
-        );
+	let hook, setMediaQueryList, setMediaQueryListOnChange;
+	if (!entry) {
+		hook = makeListenerHook(func);
+		setMediaQueryList = new Set();
+		setMediaQueryListOnChange = new Set();
+		wmFuncToEntry.set(func, { hook, setMediaQueryList, setMediaQueryListOnChange });
+		wmHookToFunc.set(hook, func);
+	} else {
+		({ hook, setMediaQueryList, setMediaQueryListOnChange } = entry);
+	}
 
-        // if the real status is the same as the one we fake, just go on
-        // or if the whole feature is disabled, obviously
-        if (fakedColorStatus === realColorStatus || fakedColorStatus === COLOR_STATUS.NO_OVERWRITE) {
-            // continue evaluating real result, no need to fake it
-            break;
-        }
+	if (isOnChange) {
+		setMediaQueryListOnChange.add(mediaQueryList);
+	} else {
+		setMediaQueryList.add(mediaQueryList);
+	}
 
-        // faking media queries is hard, and we can only return a fake object
-        const fakeResult = fakeMediaQueryResult(mediaQueryString, requestedMedia);
-        return cloneInto(
-            fakeResult,
-            window,
-            {cloneFunctions: true}
-        );
-    }
-    }
+	setMediaQueryLists.add(mediaQueryList);
 
-    // pass to default function, by default
-    return window.matchMedia(...args);
+	return hook;
 }
+
+/**
+ * Keep track of listener removal
+ * Returns hook function or null if not found
+ *
+ * @private
+ * @param {function} func original listener
+ * @param {MediaQueryList} mediaQueryList
+ * @param {boolean} isOnChange
+ * @returns {function} hook
+ */
+function _OffListener(func, mediaQueryList, isOnChange) {
+	let entry = wmFuncToEntry.get(func);
+	if (!entry) {
+		return null;
+	}
+	let { hook, setMediaQueryList, setMediaQueryListOnChange } = entry;
+
+	if (isOnChange) {
+		setMediaQueryListOnChange.delete(mediaQueryList);
+	} else {
+		setMediaQueryList.delete(mediaQueryList);
+	}
+
+	if (setMediaQueryList.size === 0 && setMediaQueryListOnChange.size === 0) {
+		setMediaQueryLists.delete(mediaQueryList);
+	}
+
+	return hook;
+}
+
+const skeleton = {
+	addListener(func) {
+		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+			typeof func !== 'function' ||
+			evaluateMediaQuery(this.media) === null
+		) {
+			return Reflect.apply(originalAddListener, this, arguments);
+		}
+		let hook = _OnListener(func, this, false);
+		return Reflect.apply(originalAddListener, this, [hook]);
+	},
+	removeListener(func) {
+		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+			typeof func !== 'function' ||
+			evaluateMediaQuery(this.media) === null
+		) {
+			return Reflect.apply(originalRemoveListener, this, arguments);
+		}
+		let hook = _OffListener(func, this, false);
+		if (!hook) {
+			return Reflect.apply(originalRemoveListener, this, arguments);
+		}
+		return Reflect.apply(originalRemoveListener, this, [hook]);
+	},
+	get matches() {
+		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]') {
+			return Reflect.apply(originalMatchesGetter, this, arguments);
+		}
+		let result = evaluateMediaQuery(this.media);
+		if (result === null) {
+			return Reflect.apply(originalMatchesGetter, this, arguments);
+		}
+		return result;
+	},
+	get onchange() {
+		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+			evaluateMediaQuery(this.media) === null
+		) {
+			return Reflect.apply(originalOnChangeGetter, this, arguments);
+		}
+		let hook = Reflect.apply(privilegedOnChangeGetter, this, arguments);
+		if (typeof hook !== 'function') {
+			return hook;
+		}
+		let func = wmHookToFunc.get(hook);
+		if (typeof func !== 'function') {
+			// !!! BAD GUY !!!
+			return null;
+		}
+		return func;
+	},
+	set onchange(func) {
+		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+			typeof func !== 'function' ||
+			evaluateMediaQuery(this.media) === null
+		) {
+			return Reflect.apply(originalOnChangeSetter, this, arguments);
+		}
+		let oldHook = Reflect.apply(privilegedOnChangeGetter, this, arguments);
+		if (typeof oldHook === 'function') {
+			let oldFunc = wmHookToFunc.get(oldHook);
+			if (!oldFunc) {
+				// !!! BAD GUY !!!
+				return Reflect.apply(originalOnChangeSetter, this, arguments);
+			}
+			_OffListener(oldFunc, this, true);
+		}
+		let hook = _OnListener(func, this, true);
+		return Reflect.apply(originalOnChangeSetter, this, [hook]);
+	},
+
+	addEventListener(type, listener, options) {
+		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+			type !== 'change' ||
+			typeof listener !== 'function' ||
+			evaluateMediaQuery(this.media) === null
+		) {
+			return Reflect.apply(originalAddEventListener, this, arguments);
+		}
+		let hook = _OnListener(listener, this, false);
+		return Reflect.apply(originalAddEventListener, this, ['change', hook, options]);
+	},
+	removeEventListener(type, listener, options) {
+		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+			type !== 'change' ||
+			typeof listener !== 'function' ||
+			evaluateMediaQuery(this.media) === null
+		) {
+			return Reflect.apply(originalRemoveEventListener, this, arguments);
+		}
+		let hook = _OffListener(listener, this, false);
+		if (!hook) {
+			return Reflect.apply(originalRemoveEventListener, this, arguments);
+		}
+		return Reflect.apply(originalRemoveEventListener, this, ['change', hook, options]);
+	}
+};
+
+/**
+ * Make a hook function for "change" event listener
+ *
+ * @private
+ * @param {function} func the original listener function
+ * @returns {function}
+ */
+function makeListenerHook(func) {
+	let dummy = unsafeObjectCreate(null);
+	return exportFunction(function(event) {
+		if (Object.prototype.toString.call(event) !== '[object MediaQueryListEvent]') {
+			return Function.prototype.apply.call(func, this, arguments);
+		}
+
+		if (!dispatching && event.isTrusted) {
+			// swallow events originating from the browser
+			return;
+		}
+
+		return Function.prototype.apply.call(func, this, arguments);
+	}, dummy, {
+		defineAs: func.name
+	});
+}
+
+/**
+ * Dispatch artificial "change" events
+ *
+ * @private
+ */
+function dispatchChangeEvents() {
+	// [CAVEAT]
+	// In vanilla Firefox, events are dispatched to `MediaQueryList`s in the order they are created.
+	// Since there is no way to keep track of the order of all `MediaQueryList`s without memory leaks,
+	// we are calling them in the order they are assigned listeners.
+	dispatching = true;
+	for (let mediaQueryList of setMediaQueryLists) {
+		let result = evaluateMediaQuery(mediaQueryList.media);
+		if (result === null) {
+			continue;
+		}
+		// [CAVEAT]
+		// https://bugzilla.mozilla.org/show_bug.cgi?id=1348213
+		// WebExtensions have no way of generating trusted events
+		let event = new MediaQueryListEvent('change', {
+			media: mediaQueryList.media,
+			matches: result
+		});
+		wmFakeEvents.add(event);
+		mediaQueryList.dispatchEvent(event);
+	}
+	dispatching = false;
+
+	jsColorStatus = fakedColorStatus;
+}
+
 
 /**
  * Apply the JS overwrite.
@@ -136,15 +315,54 @@ function matchMediaOverwrite(...args) {
 function applyJsOverwrite() {
     // do not overwrite twice
     if (overwroteMatchMedia) {
+		if (jsColorStatus !== fakedColorStatus) {
+			dispatchChangeEvents();
+		}
         return;
     }
 
-    // add hint for websites to detect this has been faked
-    // matchMediaOverwrite.FAKED = ADDON_FAKED_WARNING;
-    // DISABLED, as it could be used for tracking (which simple console statements itself cannot AFAIK)
+    // actually overwrite
 
-    // actually overwrite function
-    exportFunction(matchMediaOverwrite, window, {defineAs: "matchMedia"});
+    Reflect.defineProperty(MediaQueryListPrototype, 'addListener', {
+		configurable: true,
+		enumerable: true,
+		value: exportFunction(skeleton.addListener, window),
+		writable: true
+	});
+    Reflect.defineProperty(MediaQueryListPrototype, 'removeListener', {
+		configurable: true,
+		enumerable: true,
+		value: exportFunction(skeleton.removeListener, window),
+		writable: true
+	});
+	let descMatches = Reflect.getOwnPropertyDescriptor(skeleton, 'matches');
+    Reflect.defineProperty(MediaQueryListPrototype, 'matches', {
+		configurable: true,
+		enumerable: true,
+		get: exportFunction(descMatches.get, window)
+	});
+	let descOnchange = Reflect.getOwnPropertyDescriptor(skeleton, 'onchange');
+    Reflect.defineProperty(MediaQueryListPrototype, 'onchange', {
+		configurable: true,
+		enumerable: true,
+		get: exportFunction(descOnchange.get, window),
+		set: exportFunction(descOnchange.set, window),
+	});
+
+    Reflect.defineProperty(EventTargetPrototype, 'addEventListener', {
+		configurable: true,
+		enumerable: true,
+		value: exportFunction(skeleton.addEventListener, window),
+		writable: true
+	});
+    Reflect.defineProperty(EventTargetPrototype, 'removeEventListener', {
+		configurable: true,
+		enumerable: true,
+		value: exportFunction(skeleton.removeEventListener, window),
+		writable: true
+	});
+
+	overwroteMatchMedia = true;
 }
 
 applyJsOverwrite();

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -337,6 +337,8 @@ function dispatchChangeEvents() {
         } else {
             lastSeenJsColorStatus = systemMediaStatus;
         }
+    } else {
+        lastSeenJsColorStatus = fakedColorStatus;
     }
 
     // [CAVEAT]

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -155,7 +155,7 @@ function _OffListener(func, mediaQueryList, isOnChange) {
  * @returns {boolean}
  */
 function _checkIsMediaQueryList(obj) {
-    return (Object.prototype.toString.call(this) === '[object MediaQueryList]');
+    return (Object.prototype.toString.call(obj) === '[object MediaQueryList]');
 }
 
 const skeleton = {

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -204,7 +204,7 @@ const skeleton = {
         }
         let func = wmHookToFunc.get(hook);
         if (typeof func !== 'function') {
-            console.error('[website-dark-mode-switcher] someone called "set onchange" on an unknown MediaQueryList!');
+            console.error('[website-dark-mode-switcher] someone called "get onchange" on an unknown MediaQueryList!');
             return null;
         }
         return func;

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -267,7 +267,7 @@ const skeleton = {
         return Reflect.apply(originalOnChangeSetter, this, [hook]);
     },
 
-    addEventListener(type, listener, options) {
+    addEventListener(type, listener /* , options*/) {
         if (!checkIsMediaQueryList(this) ||
             type !== "change" ||
             typeof listener !== "function" ||
@@ -275,10 +275,11 @@ const skeleton = {
         ) {
             return Reflect.apply(originalAddEventListener, this, arguments);
         }
+        const options = arguments[2];
         const hook = trackOnListener(listener, this, false);
         return Reflect.apply(originalAddEventListener, this, ["change", hook, options]);
     },
-    removeEventListener(type, listener, options) {
+    removeEventListener(type, listener /* , options*/) {
         if (!checkIsMediaQueryList(this) ||
             type !== "change" ||
             typeof listener !== "function" ||
@@ -286,6 +287,7 @@ const skeleton = {
         ) {
             return Reflect.apply(originalRemoveEventListener, this, arguments);
         }
+        const options = arguments[2];
         const hook = trackOffListener(listener, this, false);
         if (!hook) {
             return Reflect.apply(originalRemoveEventListener, this, arguments);
@@ -441,3 +443,5 @@ function mayLogFakeWarning() {
         loggedFakedWarning = true;
     }
 }
+
+/* eslint-enable prefer-rest-params, no-setter-return */

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -51,7 +51,7 @@ let dispatching = false;
  */
 function getColorTypeFromMediaQuery(mediaQueryString) {
     // to avoid expensive RegEx, first use a simple check
-    if (!hasMediaQuery(mediaQueryString)) {
+    if (!hasColorMediaQuery(mediaQueryString)) {
         return null;
     }
 
@@ -73,7 +73,7 @@ function getColorTypeFromMediaQuery(mediaQueryString) {
  * @param {string} mediaQueryString
  * @returns {boolean}
  */
-function hasMediaQuery(mediaQueryString) {
+function hasColorMediaQuery(mediaQueryString) {
     return (mediaQueryString.includes(MEDIA_QUERY_COLOR_SCHEME));
 }
 
@@ -179,7 +179,7 @@ const skeleton = {
     addListener(func) {
         if (!checkIsMediaQueryList(this) ||
             typeof func !== 'function' ||
-            !hasMediaQuery(this.media)
+            !hasColorMediaQuery(this.media)
         ) {
             return Reflect.apply(originalAddListener, this, arguments);
         }
@@ -189,7 +189,7 @@ const skeleton = {
     removeListener(func) {
         if (!checkIsMediaQueryList(this) ||
             typeof func !== 'function' ||
-            !hasMediaQuery(this.media)
+            !hasColorMediaQuery(this.media)
         ) {
             return Reflect.apply(originalRemoveListener, this, arguments);
         }
@@ -214,7 +214,7 @@ const skeleton = {
     },
     get onchange() {
         if (!checkIsMediaQueryList(this) ||
-            !hasMediaQuery(this.media)
+            !hasColorMediaQuery(this.media)
         ) {
             return Reflect.apply(originalOnChangeGetter, this, arguments);
         }
@@ -232,7 +232,7 @@ const skeleton = {
     set onchange(func) {
         if (!checkIsMediaQueryList(this) ||
             typeof func !== 'function' ||
-            !hasMediaQuery(this.media)
+            !hasColorMediaQuery(this.media)
         ) {
             // eslint-disable-next-line no-setter-return
             return Reflect.apply(originalOnChangeSetter, this, arguments);
@@ -256,7 +256,7 @@ const skeleton = {
         if (!checkIsMediaQueryList(this) ||
             type !== 'change' ||
             typeof listener !== 'function' ||
-            !hasMediaQuery(this.media)
+            !hasColorMediaQuery(this.media)
         ) {
             return Reflect.apply(originalAddEventListener, this, arguments);
         }
@@ -267,7 +267,7 @@ const skeleton = {
         if (!checkIsMediaQueryList(this) ||
             type !== 'change' ||
             typeof listener !== 'function' ||
-            !hasMediaQuery(this.media)
+            !hasColorMediaQuery(this.media)
         ) {
             return Reflect.apply(originalRemoveEventListener, this, arguments);
         }

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -79,11 +79,11 @@ function getColorTypeFromMediaQuery(mediaQueryString) {
  * @returns {boolean|null}
  */
 function evaluateMediaQuery(mediaQueryString) {
-	let requestedMedia = getColorTypeFromMediaQuery(mediaQueryString);
-	if (requestedMedia === null) {
-		return null;
-	}
-	return (fakedColorStatus === requestedMedia);
+    let requestedMedia = getColorTypeFromMediaQuery(mediaQueryString);
+    if (requestedMedia === null) {
+        return null;
+    }
+    return (fakedColorStatus === requestedMedia);
 }
 
 /**
@@ -97,28 +97,28 @@ function evaluateMediaQuery(mediaQueryString) {
  * @returns {function} hook
  */
 function _OnListener(func, mediaQueryList, isOnChange) {
-	let entry = wmFuncToEntry.get(func);
+    let entry = wmFuncToEntry.get(func);
 
-	let hook, setMediaQueryList, setMediaQueryListOnChange;
-	if (!entry) {
-		hook = makeListenerHook(func);
-		setMediaQueryList = new Set();
-		setMediaQueryListOnChange = new Set();
-		wmFuncToEntry.set(func, { hook, setMediaQueryList, setMediaQueryListOnChange });
-		wmHookToFunc.set(hook, func);
-	} else {
-		({ hook, setMediaQueryList, setMediaQueryListOnChange } = entry);
-	}
+    let hook, setMediaQueryList, setMediaQueryListOnChange;
+    if (!entry) {
+        hook = makeListenerHook(func);
+        setMediaQueryList = new Set();
+        setMediaQueryListOnChange = new Set();
+        wmFuncToEntry.set(func, { hook, setMediaQueryList, setMediaQueryListOnChange });
+        wmHookToFunc.set(hook, func);
+    } else {
+        ({ hook, setMediaQueryList, setMediaQueryListOnChange } = entry);
+    }
 
-	if (isOnChange) {
-		setMediaQueryListOnChange.add(mediaQueryList);
-	} else {
-		setMediaQueryList.add(mediaQueryList);
-	}
+    if (isOnChange) {
+        setMediaQueryListOnChange.add(mediaQueryList);
+    } else {
+        setMediaQueryList.add(mediaQueryList);
+    }
 
-	setMediaQueryLists.add(mediaQueryList);
+    setMediaQueryLists.add(mediaQueryList);
 
-	return hook;
+    return hook;
 }
 
 /**
@@ -132,121 +132,121 @@ function _OnListener(func, mediaQueryList, isOnChange) {
  * @returns {function} hook
  */
 function _OffListener(func, mediaQueryList, isOnChange) {
-	let entry = wmFuncToEntry.get(func);
-	if (!entry) {
-		return null;
-	}
-	let { hook, setMediaQueryList, setMediaQueryListOnChange } = entry;
+    let entry = wmFuncToEntry.get(func);
+    if (!entry) {
+        return null;
+    }
+    let { hook, setMediaQueryList, setMediaQueryListOnChange } = entry;
 
-	if (isOnChange) {
-		setMediaQueryListOnChange.delete(mediaQueryList);
-	} else {
-		setMediaQueryList.delete(mediaQueryList);
-	}
+    if (isOnChange) {
+        setMediaQueryListOnChange.delete(mediaQueryList);
+    } else {
+        setMediaQueryList.delete(mediaQueryList);
+    }
 
-	if (setMediaQueryList.size === 0 && setMediaQueryListOnChange.size === 0) {
-		setMediaQueryLists.delete(mediaQueryList);
-	}
+    if (setMediaQueryList.size === 0 && setMediaQueryListOnChange.size === 0) {
+        setMediaQueryLists.delete(mediaQueryList);
+    }
 
-	return hook;
+    return hook;
 }
 
 const skeleton = {
-	addListener(func) {
-		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
-			typeof func !== 'function' ||
-			evaluateMediaQuery(this.media) === null
-		) {
-			return Reflect.apply(originalAddListener, this, arguments);
-		}
-		let hook = _OnListener(func, this, false);
-		return Reflect.apply(originalAddListener, this, [hook]);
-	},
-	removeListener(func) {
-		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
-			typeof func !== 'function' ||
-			evaluateMediaQuery(this.media) === null
-		) {
-			return Reflect.apply(originalRemoveListener, this, arguments);
-		}
-		let hook = _OffListener(func, this, false);
-		if (!hook) {
-			return Reflect.apply(originalRemoveListener, this, arguments);
-		}
-		return Reflect.apply(originalRemoveListener, this, [hook]);
-	},
-	get matches() {
-		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]') {
-			return Reflect.apply(originalMatchesGetter, this, arguments);
-		}
-		let result = evaluateMediaQuery(this.media);
-		if (result === null) {
-			return Reflect.apply(originalMatchesGetter, this, arguments);
-		}
-		return result;
-	},
-	get onchange() {
-		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
-			evaluateMediaQuery(this.media) === null
-		) {
-			return Reflect.apply(originalOnChangeGetter, this, arguments);
-		}
-		let hook = Reflect.apply(privilegedOnChangeGetter, this, arguments);
-		if (typeof hook !== 'function') {
-			return hook;
-		}
-		let func = wmHookToFunc.get(hook);
-		if (typeof func !== 'function') {
-			// !!! BAD GUY !!!
-			return null;
-		}
-		return func;
-	},
-	set onchange(func) {
-		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
-			typeof func !== 'function' ||
-			evaluateMediaQuery(this.media) === null
-		) {
-			return Reflect.apply(originalOnChangeSetter, this, arguments);
-		}
-		let oldHook = Reflect.apply(privilegedOnChangeGetter, this, arguments);
-		if (typeof oldHook === 'function') {
-			let oldFunc = wmHookToFunc.get(oldHook);
-			if (!oldFunc) {
-				// !!! BAD GUY !!!
-				return Reflect.apply(originalOnChangeSetter, this, arguments);
-			}
-			_OffListener(oldFunc, this, true);
-		}
-		let hook = _OnListener(func, this, true);
-		return Reflect.apply(originalOnChangeSetter, this, [hook]);
-	},
+    addListener(func) {
+        if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+            typeof func !== 'function' ||
+            evaluateMediaQuery(this.media) === null
+        ) {
+            return Reflect.apply(originalAddListener, this, arguments);
+        }
+        let hook = _OnListener(func, this, false);
+        return Reflect.apply(originalAddListener, this, [hook]);
+    },
+    removeListener(func) {
+        if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+            typeof func !== 'function' ||
+            evaluateMediaQuery(this.media) === null
+        ) {
+            return Reflect.apply(originalRemoveListener, this, arguments);
+        }
+        let hook = _OffListener(func, this, false);
+        if (!hook) {
+            return Reflect.apply(originalRemoveListener, this, arguments);
+        }
+        return Reflect.apply(originalRemoveListener, this, [hook]);
+    },
+    get matches() {
+        if (Object.prototype.toString.call(this) !== '[object MediaQueryList]') {
+            return Reflect.apply(originalMatchesGetter, this, arguments);
+        }
+        let result = evaluateMediaQuery(this.media);
+        if (result === null) {
+            return Reflect.apply(originalMatchesGetter, this, arguments);
+        }
+        return result;
+    },
+    get onchange() {
+        if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+            evaluateMediaQuery(this.media) === null
+        ) {
+            return Reflect.apply(originalOnChangeGetter, this, arguments);
+        }
+        let hook = Reflect.apply(privilegedOnChangeGetter, this, arguments);
+        if (typeof hook !== 'function') {
+            return hook;
+        }
+        let func = wmHookToFunc.get(hook);
+        if (typeof func !== 'function') {
+            // !!! BAD GUY !!!
+            return null;
+        }
+        return func;
+    },
+    set onchange(func) {
+        if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+            typeof func !== 'function' ||
+            evaluateMediaQuery(this.media) === null
+        ) {
+            return Reflect.apply(originalOnChangeSetter, this, arguments);
+        }
+        let oldHook = Reflect.apply(privilegedOnChangeGetter, this, arguments);
+        if (typeof oldHook === 'function') {
+            let oldFunc = wmHookToFunc.get(oldHook);
+            if (!oldFunc) {
+                // !!! BAD GUY !!!
+                return Reflect.apply(originalOnChangeSetter, this, arguments);
+            }
+            _OffListener(oldFunc, this, true);
+        }
+        let hook = _OnListener(func, this, true);
+        return Reflect.apply(originalOnChangeSetter, this, [hook]);
+    },
 
-	addEventListener(type, listener, options) {
-		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
-			type !== 'change' ||
-			typeof listener !== 'function' ||
-			evaluateMediaQuery(this.media) === null
-		) {
-			return Reflect.apply(originalAddEventListener, this, arguments);
-		}
-		let hook = _OnListener(listener, this, false);
-		return Reflect.apply(originalAddEventListener, this, ['change', hook, options]);
-	},
-	removeEventListener(type, listener, options) {
-		if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
-			type !== 'change' ||
-			typeof listener !== 'function' ||
-			evaluateMediaQuery(this.media) === null
-		) {
-			return Reflect.apply(originalRemoveEventListener, this, arguments);
-		}
-		let hook = _OffListener(listener, this, false);
-		if (!hook) {
-			return Reflect.apply(originalRemoveEventListener, this, arguments);
-		}
-		return Reflect.apply(originalRemoveEventListener, this, ['change', hook, options]);
-	}
+    addEventListener(type, listener, options) {
+        if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+            type !== 'change' ||
+            typeof listener !== 'function' ||
+            evaluateMediaQuery(this.media) === null
+        ) {
+            return Reflect.apply(originalAddEventListener, this, arguments);
+        }
+        let hook = _OnListener(listener, this, false);
+        return Reflect.apply(originalAddEventListener, this, ['change', hook, options]);
+    },
+    removeEventListener(type, listener, options) {
+        if (Object.prototype.toString.call(this) !== '[object MediaQueryList]' ||
+            type !== 'change' ||
+            typeof listener !== 'function' ||
+            evaluateMediaQuery(this.media) === null
+        ) {
+            return Reflect.apply(originalRemoveEventListener, this, arguments);
+        }
+        let hook = _OffListener(listener, this, false);
+        if (!hook) {
+            return Reflect.apply(originalRemoveEventListener, this, arguments);
+        }
+        return Reflect.apply(originalRemoveEventListener, this, ['change', hook, options]);
+    }
 };
 
 /**
@@ -257,21 +257,21 @@ const skeleton = {
  * @returns {function}
  */
 function makeListenerHook(func) {
-	let dummy = unsafeObjectCreate(null);
-	return exportFunction(function(event) {
-		if (Object.prototype.toString.call(event) !== '[object MediaQueryListEvent]') {
-			return Function.prototype.apply.call(func, this, arguments);
-		}
+    let dummy = unsafeObjectCreate(null);
+    return exportFunction(function(event) {
+        if (Object.prototype.toString.call(event) !== '[object MediaQueryListEvent]') {
+            return Function.prototype.apply.call(func, this, arguments);
+        }
 
-		if (!dispatching && event.isTrusted) {
-			// swallow events originating from the browser
-			return;
-		}
+        if (!dispatching && event.isTrusted) {
+            // swallow events originating from the browser
+            return;
+        }
 
-		return Function.prototype.apply.call(func, this, arguments);
-	}, dummy, {
-		defineAs: func.name
-	});
+        return Function.prototype.apply.call(func, this, arguments);
+    }, dummy, {
+        defineAs: func.name
+    });
 }
 
 /**
@@ -280,29 +280,29 @@ function makeListenerHook(func) {
  * @private
  */
 function dispatchChangeEvents() {
-	// [CAVEAT]
-	// In vanilla Firefox, events are dispatched to `MediaQueryList`s in the order they are created.
-	// Since there is no way to keep track of the order of all `MediaQueryList`s without memory leaks,
-	// we are calling them in the order they are assigned listeners.
-	dispatching = true;
-	for (let mediaQueryList of setMediaQueryLists) {
-		let result = evaluateMediaQuery(mediaQueryList.media);
-		if (result === null) {
-			continue;
-		}
-		// [CAVEAT]
-		// https://bugzilla.mozilla.org/show_bug.cgi?id=1348213
-		// WebExtensions have no way of generating trusted events
-		let event = new MediaQueryListEvent('change', {
-			media: mediaQueryList.media,
-			matches: result
-		});
-		wmFakeEvents.add(event);
-		mediaQueryList.dispatchEvent(event);
-	}
-	dispatching = false;
+    // [CAVEAT]
+    // In vanilla Firefox, events are dispatched to `MediaQueryList`s in the order they are created.
+    // Since there is no way to keep track of the order of all `MediaQueryList`s without memory leaks,
+    // we are calling them in the order they are assigned listeners.
+    dispatching = true;
+    for (let mediaQueryList of setMediaQueryLists) {
+        let result = evaluateMediaQuery(mediaQueryList.media);
+        if (result === null) {
+            continue;
+        }
+        // [CAVEAT]
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1348213
+        // WebExtensions have no way of generating trusted events
+        let event = new MediaQueryListEvent('change', {
+            media: mediaQueryList.media,
+            matches: result
+        });
+        wmFakeEvents.add(event);
+        mediaQueryList.dispatchEvent(event);
+    }
+    dispatching = false;
 
-	jsColorStatus = fakedColorStatus;
+    jsColorStatus = fakedColorStatus;
 }
 
 
@@ -315,54 +315,54 @@ function dispatchChangeEvents() {
 function applyJsOverwrite() {
     // do not overwrite twice
     if (overwroteMatchMedia) {
-		if (jsColorStatus !== fakedColorStatus) {
-			dispatchChangeEvents();
-		}
+        if (jsColorStatus !== fakedColorStatus) {
+            dispatchChangeEvents();
+        }
         return;
     }
 
     // actually overwrite
 
     Reflect.defineProperty(MediaQueryListPrototype, 'addListener', {
-		configurable: true,
-		enumerable: true,
-		value: exportFunction(skeleton.addListener, window),
-		writable: true
-	});
+        configurable: true,
+        enumerable: true,
+        value: exportFunction(skeleton.addListener, window),
+        writable: true
+    });
     Reflect.defineProperty(MediaQueryListPrototype, 'removeListener', {
-		configurable: true,
-		enumerable: true,
-		value: exportFunction(skeleton.removeListener, window),
-		writable: true
-	});
-	let descMatches = Reflect.getOwnPropertyDescriptor(skeleton, 'matches');
+        configurable: true,
+        enumerable: true,
+        value: exportFunction(skeleton.removeListener, window),
+        writable: true
+    });
+    let descMatches = Reflect.getOwnPropertyDescriptor(skeleton, 'matches');
     Reflect.defineProperty(MediaQueryListPrototype, 'matches', {
-		configurable: true,
-		enumerable: true,
-		get: exportFunction(descMatches.get, window)
-	});
-	let descOnchange = Reflect.getOwnPropertyDescriptor(skeleton, 'onchange');
+        configurable: true,
+        enumerable: true,
+        get: exportFunction(descMatches.get, window)
+    });
+    let descOnchange = Reflect.getOwnPropertyDescriptor(skeleton, 'onchange');
     Reflect.defineProperty(MediaQueryListPrototype, 'onchange', {
-		configurable: true,
-		enumerable: true,
-		get: exportFunction(descOnchange.get, window),
-		set: exportFunction(descOnchange.set, window),
-	});
+        configurable: true,
+        enumerable: true,
+        get: exportFunction(descOnchange.get, window),
+        set: exportFunction(descOnchange.set, window),
+    });
 
     Reflect.defineProperty(EventTargetPrototype, 'addEventListener', {
-		configurable: true,
-		enumerable: true,
-		value: exportFunction(skeleton.addEventListener, window),
-		writable: true
-	});
+        configurable: true,
+        enumerable: true,
+        value: exportFunction(skeleton.addEventListener, window),
+        writable: true
+    });
     Reflect.defineProperty(EventTargetPrototype, 'removeEventListener', {
-		configurable: true,
-		enumerable: true,
-		value: exportFunction(skeleton.removeEventListener, window),
-		writable: true
-	});
+        configurable: true,
+        enumerable: true,
+        value: exportFunction(skeleton.removeEventListener, window),
+        writable: true
+    });
 
-	overwroteMatchMedia = true;
+    overwroteMatchMedia = true;
 }
 
 applyJsOverwrite();

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -242,8 +242,7 @@ const skeleton = {
             let oldFunc = wmHookToFunc.get(oldHook);
             if (typeof oldFunc !== 'function') {
                 console.error('[website-dark-mode-switcher] someone called "set onchange" on an unknown MediaQueryList!');
-                // eslint-disable-next-line no-setter-return
-                return Reflect.apply(originalOnChangeSetter, this, arguments);
+                return;
             }
             trackOffListener(oldFunc, this, true);
         }

--- a/src/content_scripts/common.js
+++ b/src/content_scripts/common.js
@@ -8,6 +8,9 @@
 let functionalMode = null;
 let fakedColorStatus = null;
 
+// last setting seen by js
+let jsLastColorStatus = null;
+
 /* @see {@link https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme} */
 const COLOR_STATUS = Object.freeze({
     LIGHT: Symbol("prefers-color-scheme: light"),
@@ -31,6 +34,7 @@ browser.storage.sync.get("fakedColorStatus").then((settings) => {
     const newSetting = settings.fakedColorStatus || "dark";
 
     fakedColorStatus = COLOR_STATUS[newSetting.toUpperCase()];
+    jsLastColorStatus = fakedColorStatus;
 });
 
 /**

--- a/src/content_scripts/common.js
+++ b/src/content_scripts/common.js
@@ -8,6 +8,9 @@
 let functionalMode = null;
 let fakedColorStatus = null;
 
+// the color status last shown to the page javascript
+let jsColorStatus = fakedColorStatus;
+
 /* @see {@link https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme} */
 const COLOR_STATUS = Object.freeze({
     LIGHT: Symbol("prefers-color-scheme: light"),
@@ -31,6 +34,7 @@ browser.storage.sync.get("fakedColorStatus").then((settings) => {
     const newSetting = settings.fakedColorStatus || "dark";
 
     fakedColorStatus = COLOR_STATUS[newSetting.toUpperCase()];
+	jsColorStatus = fakedColorStatus;
 });
 
 /**

--- a/src/content_scripts/common.js
+++ b/src/content_scripts/common.js
@@ -34,7 +34,11 @@ browser.storage.sync.get("fakedColorStatus").then((settings) => {
     const newSetting = settings.fakedColorStatus || "dark";
 
     fakedColorStatus = COLOR_STATUS[newSetting.toUpperCase()];
-    jsLastColorStatus = fakedColorStatus;
+    if (fakedColorStatus === COLOR_STATUS.NO_OVERWRITE) {
+        jsLastColorStatus = getSystemMediaStatus();
+    } else {
+        jsLastColorStatus = fakedColorStatus;
+    }
 });
 
 /**

--- a/src/content_scripts/common.js
+++ b/src/content_scripts/common.js
@@ -9,7 +9,7 @@ let functionalMode = null;
 let fakedColorStatus = null;
 
 // last setting seen by js
-let jsLastColorStatus = null;
+let lastSeenJsColorStatus = null;
 
 /* @see {@link https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme} */
 const COLOR_STATUS = Object.freeze({
@@ -35,9 +35,9 @@ browser.storage.sync.get("fakedColorStatus").then((settings) => {
 
     fakedColorStatus = COLOR_STATUS[newSetting.toUpperCase()];
     if (fakedColorStatus === COLOR_STATUS.NO_OVERWRITE) {
-        jsLastColorStatus = getSystemMediaStatus();
+        lastSeenJsColorStatus = getSystemMediaStatus();
     } else {
-        jsLastColorStatus = fakedColorStatus;
+        lastSeenJsColorStatus = fakedColorStatus;
     }
 });
 

--- a/src/content_scripts/common.js
+++ b/src/content_scripts/common.js
@@ -3,13 +3,12 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable prefer-const */
 
+/* globals browser */
+
 // should be set/overwritten very fast by manually registered content script
 // with more settings
 let functionalMode = null;
 let fakedColorStatus = null;
-
-// the color status last shown to the page javascript
-let jsColorStatus = fakedColorStatus;
 
 /* @see {@link https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme} */
 const COLOR_STATUS = Object.freeze({
@@ -34,7 +33,6 @@ browser.storage.sync.get("fakedColorStatus").then((settings) => {
     const newSetting = settings.fakedColorStatus || "dark";
 
     fakedColorStatus = COLOR_STATUS[newSetting.toUpperCase()];
-    jsColorStatus = fakedColorStatus;
 });
 
 /**

--- a/src/content_scripts/common.js
+++ b/src/content_scripts/common.js
@@ -34,7 +34,7 @@ browser.storage.sync.get("fakedColorStatus").then((settings) => {
     const newSetting = settings.fakedColorStatus || "dark";
 
     fakedColorStatus = COLOR_STATUS[newSetting.toUpperCase()];
-	jsColorStatus = fakedColorStatus;
+    jsColorStatus = fakedColorStatus;
 });
 
 /**

--- a/src/content_scripts/common.js
+++ b/src/content_scripts/common.js
@@ -3,8 +3,6 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable prefer-const */
 
-/* globals browser */
-
 // should be set/overwritten very fast by manually registered content script
 // with more settings
 let functionalMode = null;


### PR DESCRIPTION
A redesign of applyColorSchemeJs

Hijack prototypes instead of overwriting matchMedia.
"matches" getter on MediaQueryList.
Dispatch events. Fixes #30
Track, hook and disguise "change" event listeners.
Tries to be as defensive as possible.

Highly dependent on Firefox's implementation of content scripts.