### PR TITLE
Fix content script initialization process

### DIFF
--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -28,7 +28,8 @@
         "/content_scripts/common.js",
         "/content_scripts/applyColorSchemeJs.js",
         "/content_scripts/applyColorSchemeCss.js",
-        "/content_scripts/updateRequest.js"
+        "/content_scripts/updateRequest.js",
+        "/content_scripts/initialize.js"
       ],
       "all_frames": true,
       "match_about_blank": true,

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -28,7 +28,8 @@
         "/content_scripts/common.js",
         "/content_scripts/applyColorSchemeJs.js",
         "/content_scripts/applyColorSchemeCss.js",
-        "/content_scripts/updateRequest.js"
+        "/content_scripts/updateRequest.js",
+        "/content_scripts/initialize.js"
       ],
       "all_frames": true,
       "match_about_blank": true,

--- a/src/background/modules/ActionButton.js
+++ b/src/background/modules/ActionButton.js
@@ -51,7 +51,7 @@ function adjustUserIndicator(newColorSetting) {
  *
  * @function
  * @private
- * @param  {boolean} newColorSetting
+ * @param  {string} newColorSetting
  * @returns {void}
  */
 function propagateNewSetting(newColorSetting) {
@@ -60,6 +60,9 @@ function propagateNewSetting(newColorSetting) {
         fakedColorStatus: newColorSetting,
         source: COMMUNICATION_MESSAGE_SOURCE.BROWSER_ACTION
     };
+
+    // reinject new setting
+    CssAnalysis.injectContentScript(fakedColorStatus);
 
     // send to all tabs
     browser.tabs.query({
@@ -95,7 +98,6 @@ export async function init() {
         propagateNewSetting(fakedColorStatus);
         adjustUserIndicator(fakedColorStatus);
         await AddonSettings.set("fakedColorStatus", fakedColorStatus);
-        CssAnalysis.triggerNewColorStatus();
     });
     browser.browserAction.setBadgeTextColor({
         color: BADGE_COLOR

--- a/src/background/modules/CssAnalysis.js
+++ b/src/background/modules/CssAnalysis.js
@@ -25,7 +25,7 @@ export async function injectContentScript(fakedColorStatus) {
     const newContentScript = await browser.contentScripts.register({
         matches: TAB_FILTER_URLS,
         js: [{
-            code: `;
+            code: `
                     var initialSettings = JSON.parse('${JSON.stringify(settings)}');
                     if (typeof initializeContentScripts === "function") {
                         initializeContentScripts(initialSettings);

--- a/src/content_scripts/applyColorSchemeCss.js
+++ b/src/content_scripts/applyColorSchemeCss.js
@@ -232,7 +232,19 @@ function applyStyleOnFail() {
     }
 }
 
-// apply style when DOM content is loaded
-document.addEventListener("DOMContentLoaded", applyWantedStyle);
-// apply style when content is fully loaded
-window.addEventListener("load", applyStyleOnFail);
+/* eslint-disable no-unused-vars */
+
+/**
+ * Initialize applyColorSchemeCss.js
+ *
+ * @public
+ * @returns {void}
+ */
+function initializeApplyColorSchemeCss() {
+    // apply style when DOM content is loaded
+    document.addEventListener("DOMContentLoaded", applyWantedStyle);
+    // apply style when content is fully loaded
+    window.addEventListener("load", applyStyleOnFail);
+}
+
+/* eslint-enable no-unused-vars */

--- a/src/content_scripts/applyColorSchemeJs.js
+++ b/src/content_scripts/applyColorSchemeJs.js
@@ -6,8 +6,6 @@
 
 "use strict";
 
-let overwroteMatchMedia = false;
-
 const ADDON_FAKED_WARNING = "MediaQueryList has been faked by add-on website-dark-mode-switcher; see https://github.com/rugk/website-dark-mode-switcher/. If it causes any problems, please open an issue.";
 let loggedFakedWarning = false;
 
@@ -39,12 +37,13 @@ const unsafeObjectCreate = window.wrappedJSObject.Object.create;
 // Whether we are dispatching "change" events
 let dispatching = false;
 
-/* globals COLOR_STATUS, MEDIA_QUERY_COLOR_SCHEME, MEDIA_QUERY_PREFER_COLOR, fakedColorStatus, getSystemMediaStatus, lastSeenJsColorStatus:writable */
+// last setting seen by js
+let lastSeenJsColorStatus = null;
+
+/* globals COLOR_STATUS, MEDIA_QUERY_COLOR_SCHEME, MEDIA_QUERY_PREFER_COLOR, fakedColorStatus, getSystemMediaStatus */
 
 // eslint does not include X-Ray vision functions, see https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
 /* globals exportFunction */
-
-/* eslint-disable prefer-rest-params, no-setter-return */
 
 /**
  * Returns the COLOR_STATUS for a media query string.
@@ -188,6 +187,8 @@ function checkIsMediaQueryList(obj) {
     return (Object.prototype.toString.call(obj) === "[object MediaQueryList]");
 }
 
+/* eslint-disable prefer-rest-params, no-setter-return */
+
 /**
  * Kludge "skeleton" to make exportFunction()-ed .name and .toString() as expected.
  * such as "get onchange", "set onchange".
@@ -325,6 +326,8 @@ function makeListenerHook(listener) {
     });
 }
 
+/* eslint-enable prefer-rest-params, no-setter-return */
+
 /**
  * Dispatch artificial "change" events
  *
@@ -369,25 +372,42 @@ function dispatchChangeEvents() {
 }
 
 /**
- * Apply the JS overwrite.
+ * Logs ADDON_FAKED_WARNING if not already did
  *
- * @function
+ * @private
  * @returns {void}
  */
-function applyJsOverwrite() {
-    // do not overwrite twice
-    if (overwroteMatchMedia) {
-        dispatchChangeEvents();
-        return;
+function mayLogFakeWarning() {
+    if (!loggedFakedWarning) {
+        console.log(ADDON_FAKED_WARNING);
+        loggedFakedWarning = true;
     }
+}
 
+/* eslint-disable no-unused-vars */
+
+/**
+ * Do things on settings change
+ *
+ * @public
+ * @returns {void}
+ */
+function applyNewSettingsJs() {
+    dispatchChangeEvents();
+}
+
+/**
+ * Initialize applyColorSchemeJs.js
+ *
+ * @public
+ * @returns {void}
+ */
+function initializeApplyColorSchemeJs() {
     if (fakedColorStatus === COLOR_STATUS.NO_OVERWRITE) {
         lastSeenJsColorStatus = getSystemMediaStatus();
     } else {
         lastSeenJsColorStatus = fakedColorStatus;
     }
-
-    // actually overwrite
 
     Reflect.defineProperty(MediaQueryListPrototype, "addListener", {
         configurable: true,
@@ -427,23 +447,6 @@ function applyJsOverwrite() {
         value: exportFunction(skeleton.removeEventListener, window),
         writable: true
     });
-
-    overwroteMatchMedia = true;
 }
 
-applyJsOverwrite();
-
-/**
- * Logs ADDON_FAKED_WARNING if not already did
- *
- * @private
- * @returns {void}
- */
-function mayLogFakeWarning() {
-    if (!loggedFakedWarning) {
-        console.log(ADDON_FAKED_WARNING);
-        loggedFakedWarning = true;
-    }
-}
-
-/* eslint-enable prefer-rest-params, no-setter-return */
+/* eslint-enable no-unused-vars */

--- a/src/content_scripts/common.js
+++ b/src/content_scripts/common.js
@@ -8,9 +8,6 @@
 let functionalMode = null;
 let fakedColorStatus = null;
 
-// last setting seen by js
-let lastSeenJsColorStatus = null;
-
 /* @see {@link https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme} */
 const COLOR_STATUS = Object.freeze({
     LIGHT: Symbol("prefers-color-scheme: light"),
@@ -26,19 +23,6 @@ const MEDIA_QUERY_PREFER_COLOR = Object.freeze({
     [COLOR_STATUS.LIGHT]: /^\s*\(prefers-color-scheme:\s*light\)\s*$/,
     [COLOR_STATUS.DARK]: /^\s*\(prefers-color-scheme:\s*dark\)\s*$/,
     [COLOR_STATUS.NO_PREFERENCE]: /^\s*\(prefers-color-scheme:\s*no-preference\)\s*$/,
-});
-
-// request and update setting as fast as possible
-browser.storage.sync.get("fakedColorStatus").then((settings) => {
-    // ATTENTION: hardcoded default value here!
-    const newSetting = settings.fakedColorStatus || "dark";
-
-    fakedColorStatus = COLOR_STATUS[newSetting.toUpperCase()];
-    if (fakedColorStatus === COLOR_STATUS.NO_OVERWRITE) {
-        lastSeenJsColorStatus = getSystemMediaStatus();
-    } else {
-        lastSeenJsColorStatus = fakedColorStatus;
-    }
 });
 
 /**

--- a/src/content_scripts/initialize.js
+++ b/src/content_scripts/initialize.js
@@ -1,0 +1,46 @@
+/**
+ * Initialize various pieces of the content script
+ */
+"use strict";
+
+/* eslint-disable no-unused-vars */
+
+/* globals initializeUpdateRequest, initializeApplyColorSchemeCss, initializeApplyColorSchemeJs */
+/* globals functionalMode:writable, fakedColorStatus:writable, COLOR_STATUS */
+
+// initial settings at document-start, will be filled by a dynamic content script
+// eslint-disable-next-line no-var
+var initialSettings;
+
+let alreadyInitialized = false;
+
+/**
+ * Initialize content scripts
+ *
+ * @public
+ * @param {Object} settings 
+ * @returns {void}
+ */
+function initializeContentScripts(settings) {
+    if (alreadyInitialized) {
+        return;
+    }
+    alreadyInitialized = true;
+
+    functionalMode = settings.functionalMode;
+
+    // ATTENTION: hardcoded default value here!
+    const newSetting = settings.fakedColorStatus || "dark";
+
+    fakedColorStatus = COLOR_STATUS[newSetting.toUpperCase()];
+
+    initializeApplyColorSchemeJs();
+    initializeApplyColorSchemeCss();
+    initializeUpdateRequest();
+}
+
+if (typeof initialSettings !== "undefined") {
+    initializeContentScripts(initialSettings);
+}
+
+/* eslint-enable no-unused-vars */

--- a/src/content_scripts/initialize.js
+++ b/src/content_scripts/initialize.js
@@ -8,7 +8,11 @@
 /* globals initializeUpdateRequest, initializeApplyColorSchemeCss, initializeApplyColorSchemeJs */
 /* globals functionalMode:writable, fakedColorStatus:writable, COLOR_STATUS */
 
-// initial settings at document-start, will be filled by a dynamic content script
+/**
+ * Initial settings at document-start, will be filled by a dynamic content script
+ * Using "var" here because of Temporal Dead Zone
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz}
+ */
 // eslint-disable-next-line no-var
 var initialSettings;
 

--- a/src/content_scripts/updateRequest.js
+++ b/src/content_scripts/updateRequest.js
@@ -5,7 +5,7 @@
 /* globals fakedColorStatus, functionalMode */ // eslint-disable-line no-unused-vars
 
 // other parts of add-on
-/* globals COLOR_STATUS, applyJsOverwrite, applyWantedStyle */
+/* globals COLOR_STATUS, applyNewSettingsJs, applyWantedStyle */
 
 const NEW_SETTING = "newSetting";
 const NEW_SETTING_ADDITIONAL = "newSettingAdditional";
@@ -24,7 +24,7 @@ function processMessage(request) {
         fakedColorStatus = COLOR_STATUS[request.fakedColorStatus.toUpperCase()]; // eslint-disable-line no-unused-vars
 
         // trigger functions
-        applyJsOverwrite(); // actually does not need to be retriggered, as the JS-overwrite does not need to be recreated
+        applyNewSettingsJs();
         applyWantedStyle();
         break;
     case NEW_SETTING_ADDITIONAL:
@@ -38,5 +38,17 @@ function processMessage(request) {
     }
 }
 
-// add listener for incoming messages
-browser.runtime.onMessage.addListener(processMessage);
+/* eslint-disable no-unused-vars */
+
+/**
+ * Initialize updateRequest.js
+ *
+ * @public
+ * @returns {void}
+ */
+function initializeUpdateRequest() {
+    // add listener for incoming messages
+    browser.runtime.onMessage.addListener(processMessage);
+}
+
+/* eslint-enable no-unused-vars */

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,7 +28,8 @@
         "/content_scripts/common.js",
         "/content_scripts/applyColorSchemeJs.js",
         "/content_scripts/applyColorSchemeCss.js",
-        "/content_scripts/updateRequest.js"
+        "/content_scripts/updateRequest.js",
+        "/content_scripts/initialize.js"
       ],
       "all_frames": true,
       "match_about_blank": true,


### PR DESCRIPTION
Continuing from https://github.com/rugk/website-dark-mode-switcher/pull/35#issuecomment-808910757 -> https://github.com/rugk/website-dark-mode-switcher/pull/35#issuecomment-808911585 -> https://github.com/rugk/website-dark-mode-switcher/pull/35#issuecomment-808918869 -> https://github.com/rugk/website-dark-mode-switcher/pull/35#issuecomment-809203337

Remove usage of browser.storage.sync.get
Streamline the initialization process
Fix race conditions
No more page-observable period of null fakedColorStatus
Separate initialization and setting syncing in applyColorSchemeJs.js
Fix minor typing error - (boolean "newColorSetting"?)

I used `var` ... to be on the safe side
```
(function() {
  if (typeof test === 'undefined') {
    return;
  }
  let test;
})();
```

Sometimes, Firefox seems to load content scripts one-by-one, instead of all at once.
This necessitates moving the initialization process into `initialize.js` that runs last (of static content scripts).
Specifically, at the time when `common.js` runs, it is possible for `initializeApplyColorSchemeJs` to be undefined, for example.
This also means it is safer to use `var` for `initialSettings`.

I used `JSON.parse` and `JSON.stringify` to be as robust (and future-proof) as possible.