### PR TITLE
Implement fundamentals of clever dark mode

### DIFF
--- a/src/background/modules/ActionButton.js
+++ b/src/background/modules/ActionButton.js
@@ -54,5 +54,3 @@ export function init() {
         color: BADGE_BACKGROUND_COLOR
     });
 }
-
-

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -23,7 +23,7 @@ function applyPrefersColorSchemeOverride(optionValue) {
 /**
  * Apply the setting and show it as the used one.
  *
- * @param {string} currentSetting The settting to show as the currently selected one.
+ * @param {string} currentSetting The setting to show as the currently selected one.
  * @returns {void}
  */
 function applySetting(currentSetting) {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -68,15 +68,15 @@
 					</div>
 				</p>
 				<ul>
-					<!-- <li>
+					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="cleverDarkMode" name="cleverDarkMode">
 							<label data-i18n="__MSG_optionCleverDarkMode__" for="cleverDarkMode">Clever dark mode</label>
 						</div>
 						<div class="line indent">
-							<span class="helper-text" data-i18n="__MSG_optionCleverDarkModeDescr__">Always toggle the current dark mode in the context of the current browser theme.</span>
+							<span class="helper-text" data-i18n="__MSG_optionCleverDarkModeDescr__">Shows the current style in the toolbar and toggles the current dark mode depending on the current website style.</span>
 						</div>
-					</li> -->
+					</li>
 					<li class="line">
 						<label for="prefersColorSchemeOverride" data-i18n="__MSG_optionsWebsiteStyle__">Website style: </label>
 					</li>


### PR DESCRIPTION
Fixes https://github.com/rugk/website-dark-mode-switcher/issues/45

## TODO

* [ ] currently still runs into a recursive loop, due to the fact that the design change the add-on triggers here is of course also catched by the listener we need for changing the option, which is a little ugly – I already tried preventing that with unregistering and reregistering the listener before respectively after changing it, but that did not fix the issue. Also an additional timeout does not work.
* [ ] Generally, it needs to be thought about whether this works in general, because of course, as soon as the add-on overrides the Firefox setting, it cannot listen to system events for design changes anymore at all – for obvious reasons.
   When we know to read that setting, we can temporarily disable the override (which is a little ugly hack as it can cause design distortions? Or is the new design always correct?) – that is what I have implemented currently –, but of course obvious reasons an interactive listener/trigger/reaction upon such a change cannot be implemented.
   _Unless_ (and this may need investigation), such a listener uses the setting when it has been registered. If that would work, we'd only need to register the listener for `browser` or `system` mode (maybe user-selectable) once, and can still trigger the change. Still complex though…
  An alternative would be a simple polling algorithm, but that is also ugly, especially as it would need to temporarily remove the override (see above), so that would likely definitively lead to visual gliches.

So maybe this is not possible at all, and it's not useful to pursue this idea anymore…

## resources

* https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries
* https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener
* https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
* https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
* 